### PR TITLE
TypeAdapter rollback

### DIFF
--- a/src/main/java/com/oneops/search/msg/processor/MessageProcessor.java
+++ b/src/main/java/com/oneops/search/msg/processor/MessageProcessor.java
@@ -27,7 +27,7 @@ import java.lang.reflect.Type;
  */
 public interface MessageProcessor {
     Gson GSON = new Gson();
-    Gson GSON_ES = new GsonBuilder().registerTypeAdapter(String.class, (JsonDeserializer<String>) (jsonElement, type, jsonDeserializationContext) -> jsonElement.toString()).setDateFormat(CmsConstants.SEARCH_TS_PATTERN).create();
+    Gson GSON_ES = new GsonBuilder().setDateFormat(CmsConstants.SEARCH_TS_PATTERN).create();
 
 
     /**


### PR DESCRIPTION
We no longer need to support expanded and non expanded attributes because expansion is happening in a parallel tree,  so rolling back this TypeAdapter since it may have caused issues with nested messages. 